### PR TITLE
Remove/Replace call to deprecated get_currentuserinfo()

### DIFF
--- a/includes/embed.php
+++ b/includes/embed.php
@@ -6,8 +6,7 @@ add_action('wp_head', 'add_drift');
 // If we can indentify the current user output
 function get_drift_identify()
 {
-  global $current_user;
-  get_currentuserinfo();
+  $current_user = wp_get_current_user();
   if ($current_user->user_email) {
     $sanitized_email = sanitize_email($current_user->user_email);
     echo "<!-- Start Identify call for Drift -->\n";

--- a/includes/embed.php
+++ b/includes/embed.php
@@ -36,8 +36,6 @@ function add_drift()
     return;
   }
 
-  global $current_user;
-  get_currentuserinfo();
   $options = get_option('Drift_settings');
 
   // If options is empty then exit


### PR DESCRIPTION
- replace deprecated call to `get_currentuserinfo()` with `wp_get_current_user()`
- remove call to unused (and deprecated) function `get_currentuserinfo()`
