### PR TITLE
v2.0.1 Update bad use of this within static function

### DIFF
--- a/drift.php
+++ b/drift.php
@@ -3,7 +3,7 @@
 Plugin Name: Drift
 Plugin URI: https://wordpress.org/plugins/drift/
 Description: Adds 100% free live chat & targeted messages to your website. Designed for internet businesses like yours to increase sales, conversions and better support your customers.
-Version: 2.0.0
+Version: 2.0.1
 Author: Drift
 Author URI: https://www.drift.com/?ref=wordpress
 License: GPLv3

--- a/includes/class-drift-main.php
+++ b/includes/class-drift-main.php
@@ -653,7 +653,7 @@ if ( ! class_exists( 'Drift_Main' ) ) {
 		 * @global object $wpdb Used for database queries.
 		 */
 		public static function release_updates() {
-			if ( version_compare( $this->version, '1.8.4', '>' ) ) {
+			if ( version_compare( '2.0.0', '1.8.4', '>' ) ) {
 				$old = get_option( 'Drift_settings' ); // The old name of the option
 				if ( isset( $old ) ) {
 					global $wpdb;

--- a/includes/class-drift-main.php
+++ b/includes/class-drift-main.php
@@ -62,7 +62,7 @@ if ( ! class_exists( 'Drift_Main' ) ) {
 		 */
 		public function __construct() {
 			$this->plugin_url = plugins_url( '', dirname( __FILE__ ) );
-			$this->version    = '2.0.0';
+			$this->version    = '2.0.1';
 			$this->define_hooks();
 		}
 

--- a/languages/drift-ro_RO.po
+++ b/languages/drift-ro_RO.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Drift 2.0.0\n"
+"Project-Id-Version: Drift 2.0.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-26 15:10+0300\n"
 "PO-Revision-Date: 2019-07-01 18:42+0300\n"

--- a/languages/drift.pot
+++ b/languages/drift.pot
@@ -3,7 +3,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Drift 2.0.0\n"
+"Project-Id-Version: Drift 2.0.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/drift\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Contributors: Drift
 Tags: drift, live chat, chat, communication, sales, marketing, announcements, talk to customers, customer feedback, feedback, chat plugin, free, free chat, chatra, livechat, slack, intercom, hubspot, salesforce, zapier, hellobar, hello bar, popup, ontraport, pardot, klaviyo, popup, exit intent, growth, subscribers, subscription, email form,  analytics,  widget, lightbox, inbound marketing, welcome mat, landing pagelivechat, olark, boldchat, online chat, online support, in-app chat, instant message, helpdesk, php live chat, snapengage, support software, website chat, WordPress chat, WordPress live chat, WordPress live chat plugin, zendesk, zopim, zopim live chat, tawk, tawk.to, tawkto, jivosite, snapengage,chat widget
 Requires at least: 4.9
 Requires PHP: 5.6
-Stable tag: 2.0.0
-Version: 2.0.0
+Stable tag: 2.0.1
+Version: 2.0.1
 Tested up to: 5.2.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -123,6 +123,10 @@ Step-by-step Guide:
 * Finally, make full use of our Dashboard to manage your chat widget.
 
 == Changelog ==
+
+= 2.0.1 =
+*Release date: July 16th, 2019*
+* BUGFIX: Fixed poor usage of this in static method
 
 = 2.0.0 =
 *Release date: July, 2019*


### PR DESCRIPTION
Fixes this reported error with the release of v2.0.0:

`Fatal error: Using $this when not in object context in plugins/drift/includes/class-drift-main.php on line 656`